### PR TITLE
Add KeyPair::into_parts and BBSplusPrivateKey::public_key

### DIFF
--- a/src/bbsplus/keys.rs
+++ b/src/bbsplus/keys.rs
@@ -97,6 +97,11 @@ impl BBSplusSecretKey {
         hex::encode(sk_bytes)
     }
 
+    /// Returns the corresponding [`BBSplusPublicKey`].
+    pub fn public_key(&self) -> BBSplusPublicKey {
+        BBSplusPublicKey(sk_to_pk(self.0))
+    }
+
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, Error> {
         let bytes: [u8; Scalar::BYTES] = bytes
             .try_into()

--- a/src/keys/pair.rs
+++ b/src/keys/pair.rs
@@ -35,6 +35,11 @@ where
         &self.private
     }
 
+    /// Returns the couple `(sk, pk)`.
+    pub fn into_parts(self) -> (S::PrivKey, S::PubKey) {
+        (self.private, self.public)
+    }
+
     pub fn write_keypair_to_file(&self, file: Option<String>) {
         println!("writhing to file...");
 


### PR DESCRIPTION
`KeyPair::into_parts` allows to obtain both `sk` and `pk` without cloning them out of `KeyPair`.
`BBSplusPrivateKey::public_key` let's you easily compute the corresponding public key.