### PR TITLE
Allow `no_std` and fewer dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,37 +10,31 @@ rust-version = "1.65"
 keywords = [ "crypto", "signatures", "zero-knowledge", "bbs", "blind-signature" ]
 categories = [ "cryptography", "authentication" ]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 rand = {version = "0.8.5"}
 zeroize = { version = "1.5" }
-serde = { version = "1.0.25", default-features = false, features = ["derive", "serde_derive"] }
-serde_json = "1.0.59"
-hex = "0.4.3"
-thiserror = "1.0.30"
+serde = { version = "1.0.25", default-features = false, features = ["alloc", "derive"] }
+hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+thiserror = {version = "1.0", default-features = false, package = "thiserror-nostd-notrait"}
+sha3 = { version = "0.10.8", optional = true, default-features = false }
+sha2 = { version = "0.10.6", optional = true, default-features = false }
+serde_json = { version = "1.0.59", optional = true }
+digest = "0.10.6"
 
 # cl03
 rug = { version = "1.19.2", features = ["serde"], optional = true }
 
-
-sha3 = "0.10.8"
-sha2 = "0.10.6"
-hkdf = "0.12.3"
-digest = "0.10.6"
-
 # bbsplus
-bls12_381_plus = { version = "0.8.13", optional = true }
-ff = "0.13.0"
-group = "0.10"
+bls12_381_plus = { version = "0.8.18", optional = true, default-features = false, features = ["alloc", "groups", "pairings"] }
+ff = { version = "0.13.0", default-features = false }
+group = "0.13"
 elliptic-curve = "0.13.4"
 
-
+[dev-dependencies]
 cargo-license = "0.5.1"
 log = "0.4.0"
 env_logger = "0.10.0"
 dotenv = "0.15.0"
-
 
 
 [lib]
@@ -48,9 +42,11 @@ name = "zkryptium"
 path = "src/lib.rs"
 
 [features]
-default = ["bbsplus"]
-cl03 = ["dep:rug"]
-bbsplus = ["dep:bls12_381_plus"]
+default = ["bbsplus", "std"]
+std = ["dep:serde_json", "sha2?/std", "sha3?/std", "thiserror/std"]
+min_bbs = ["dep:bls12_381_plus"]
+cl03 = ["dep:rug", "dep:sha2"]
+bbsplus = ["min_bbs", "dep:sha2", "dep:sha3", "rand/std", "rand/std_rng"]
 
 
 [[example]]

--- a/src/bbsplus/blind.rs
+++ b/src/bbsplus/blind.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::{borrow::ToOwned, vec::Vec};
 use super::{
     commitment::BlindFactor,
     keys::{BBSplusPublicKey, BBSplusSecretKey},

--- a/src/bbsplus/ciphersuites.rs
+++ b/src/bbsplus/ciphersuites.rs
@@ -13,10 +13,11 @@
 // limitations under the License.
 
 use crate::schemes::algorithms::Ciphersuite;
-use elliptic_curve::hash2curve::{ExpandMsg, ExpandMsgXmd, ExpandMsgXof};
+use elliptic_curve::hash2curve::ExpandMsg;
+#[cfg(feature = "bbsplus")]
+use elliptic_curve::hash2curve::{ExpandMsgXmd, ExpandMsgXof};
+#[cfg(feature = "bbsplus")]
 use serde::{Deserialize, Serialize};
-use sha2::Sha256;
-use sha3::Shake256;
 
 pub trait BbsCiphersuite: Eq + 'static + Ciphersuite {
     const ID: &'static [u8];
@@ -41,11 +42,14 @@ pub trait BbsCiphersuite: Eq + 'static + Ciphersuite {
     const IKM_LEN: usize = 32;
 }
 
+#[cfg(feature = "bbsplus")]
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct Bls12381Shake256 {}
+#[cfg(feature = "bbsplus")]
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct Bls12381Sha256 {}
 
+#[cfg(feature = "bbsplus")]
 impl BbsCiphersuite for Bls12381Shake256 {
     const ID: &'static [u8] = b"BBS_BLS12381G1_XOF:SHAKE-256_SSWU_RO_";
     const API_ID: &'static [u8] = b"BBS_BLS12381G1_XOF:SHAKE-256_SSWU_RO_H2G_HM2S_";
@@ -57,11 +61,12 @@ impl BbsCiphersuite for Bls12381Shake256 {
     const BLIND_PROOF_DST: &'static [u8] =
         b"BBS_BLS12381G1_XOF:SHAKE-256_SSWU_RO_H2G_HM2S_PROOF_MOCK_RANDOM_SCALARS_DST_";
     const GENERATOR_SIG_DST: &'static [u8] = b"BBS_BLS12381G1_XOF:SHAKE-256_SSWU_RO_SIG_DET_DST_";
-    type Expander = ExpandMsgXof<Shake256>;
+    type Expander = ExpandMsgXof<sha3::Shake256>;
 
     const P1: &'static str = "8929dfbc7e6642c4ed9cba0856e493f8b9d7d5fcb0c31ef8fdcd34d50648a56c795e106e9eada6e0bda386b414150755";
 }
 
+#[cfg(feature = "bbsplus")]
 impl BbsCiphersuite for Bls12381Sha256 {
     const ID: &'static [u8] = b"BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_";
     const API_ID: &'static [u8] = b"BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_H2G_HM2S_";
@@ -73,7 +78,7 @@ impl BbsCiphersuite for Bls12381Sha256 {
     const BLIND_PROOF_DST: &'static [u8] =
         b"BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_H2G_HM2S_PROOF_MOCK_RANDOM_SCALARS_DST_";
     const GENERATOR_SIG_DST: &'static [u8] = b"BBS_BLS12381G1_XMD:SHA-256_SSWU_RO_SIG_DET_DST_";
-    type Expander = ExpandMsgXmd<Sha256>;
+    type Expander = ExpandMsgXmd<sha2::Sha256>;
 
     const P1: &'static str = "a8ce256102840821a3e94ea9025e4662b205762f9776b3a766c872b948f1fd225e7c59698588e70d11406d161b4e28c9" ;
 }

--- a/src/bbsplus/commitment.rs
+++ b/src/bbsplus/commitment.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::vec::Vec;
 use super::proof::BBSplusZKPoK;
 use crate::{
     bbsplus::{ciphersuites::BbsCiphersuite, generators::Generators},

--- a/src/bbsplus/generators.rs
+++ b/src/bbsplus/generators.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::{vec::Vec, string::String};
 use super::ciphersuites::BbsCiphersuite;
 use crate::utils::util::bbsplus_utils::i2osp;
 use bls12_381_plus::G1Projective;

--- a/src/bbsplus/keys.rs
+++ b/src/bbsplus/keys.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::{borrow::ToOwned, string::String};
 use super::ciphersuites::BbsCiphersuite;
 use crate::{
     errors::Error,
@@ -268,14 +269,14 @@ mod tests {
 
     #[test]
     fn keypair_sha256() {
-        key_pair_gen::<BbsBls12381Sha256>("./fixture_data/bls12-381-sha-256/keyPair.json");
+        key_pair_gen::<BbsBls12381Sha256>("./fixture_data/bls12-381-sha-256/keypair.json");
     }
 
     //KEYPAIR - SHAKE256
 
     #[test]
     fn keypair_shake256() {
-        key_pair_gen::<BbsBls12381Shake256>("./fixture_data/bls12-381-shake-256/keyPair.json");
+        key_pair_gen::<BbsBls12381Shake256>("./fixture_data/bls12-381-shake-256/keypair.json");
     }
 
     fn key_pair_gen<S: Scheme>(filename: &str)

--- a/src/bbsplus/proof.rs
+++ b/src/bbsplus/proof.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::{borrow::ToOwned, vec::Vec};
 use super::{
     ciphersuites::BbsCiphersuite, commitment::BlindFactor, generators::Generators,
     keys::BBSplusPublicKey, signature::BBSplusSignature,

--- a/src/bbsplus/signature.rs
+++ b/src/bbsplus/signature.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::{borrow::ToOwned, vec::Vec};
 use super::keys::{BBSplusPublicKey, BBSplusSecretKey};
 use crate::{
     bbsplus::{ciphersuites::BbsCiphersuite, generators::Generators},

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::string::String;
 use thiserror::Error;
 
 #[derive(Error, Clone, Debug)]

--- a/src/keys/pair.rs
+++ b/src/keys/pair.rs
@@ -15,7 +15,6 @@
 use crate::schemes::algorithms::Scheme;
 use serde::Deserialize;
 use serde::Serialize;
-use std::env;
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub struct KeyPair<S: Scheme> {
@@ -40,20 +39,19 @@ where
         (self.private, self.public)
     }
 
+    #[cfg(feature = "std")]
     pub fn write_keypair_to_file(&self, file: Option<String>) {
         println!("writhing to file...");
 
-        let file = file.unwrap_or(String::from("../fixtures/fixture_data/keyPair.json"));
-        let current_path = env::current_dir().unwrap();
+        let file = file.unwrap_or_else(|| String::from("../fixtures/fixture_data/keyPair.json"));
+        let current_path = std::env::current_dir().unwrap();
         let file_to_write = current_path.join(file);
 
-        std::fs::write(
+        if  std::fs::write(
             &file_to_write,
             serde_json::to_string_pretty(&self).expect("failed to serializing key pair"),
-        )
-        .expect(&format!(
-            "failed to write key pair to file: {}",
-            file_to_write.to_str().unwrap()
-        ));
+        ).is_err() {
+            panic!("failed to write key pair to file: {file_to_write:?}");
+        }
     }
 }

--- a/src/keys/traits.rs
+++ b/src/keys/traits.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use alloc::string::String;
 use serde::{de::DeserializeOwned, Serialize};
 
 pub trait PublicKey: Serialize + DeserializeOwned + Send + Sync + 'static {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,13 +15,18 @@
 #![allow(non_snake_case)]
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[allow(unused)]
+#[macro_use]
+extern crate alloc;
 
 pub mod errors;
 pub mod keys;
 pub mod schemes;
 pub mod utils;
 
-#[cfg(feature = "bbsplus")]
+#[cfg(feature = "min_bbs")]
 pub mod bbsplus;
 #[cfg(feature = "cl03")]
 pub mod cl03;

--- a/src/schemes/algorithms.rs
+++ b/src/schemes/algorithms.rs
@@ -15,11 +15,12 @@
 use crate::keys::traits::{PrivateKey, PublicKey};
 use digest::HashMarker;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use std::marker::PhantomData;
 
 #[cfg(feature = "bbsplus")]
+use crate::bbsplus::ciphersuites::{Bls12381Sha256, Bls12381Shake256};
+#[cfg(feature = "min_bbs")]
 use crate::bbsplus::{
-    ciphersuites::{BbsCiphersuite, Bls12381Sha256, Bls12381Shake256},
+    ciphersuites::BbsCiphersuite,
     keys::{BBSplusPublicKey, BBSplusSecretKey},
 };
 
@@ -37,17 +38,18 @@ pub type BbsBls12381Sha256 = BBSplus<Bls12381Sha256>;
 #[cfg(feature = "cl03")]
 pub type CL03_CL1024_SHA256 = CL03<CL1024Sha256>;
 
-#[cfg(feature = "bbsplus")]
+#[cfg(feature = "min_bbs")]
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
-pub struct BBSplus<CS: BbsCiphersuite>(PhantomData<CS>);
+pub struct BBSplus<CS: BbsCiphersuite>(core::marker::PhantomData<CS>);
 
 #[cfg(feature = "cl03")]
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
-pub struct CL03<CS: CLCiphersuite>(PhantomData<CS>);
+pub struct CL03<CS: CLCiphersuite>(core::marker::PhantomData<CS>);
 
 pub trait Ciphersuite: 'static + Eq {
     type HashAlg: HashMarker;
 }
+
 #[cfg(feature = "bbsplus")]
 impl Ciphersuite for Bls12381Sha256 {
     type HashAlg = sha2::Sha256;
@@ -63,7 +65,7 @@ pub trait Scheme: Eq + 'static + Sized + Serialize + DeserializeOwned {
     type PubKey: PublicKey;
 }
 
-#[cfg(feature = "bbsplus")]
+#[cfg(feature = "min_bbs")]
 impl<CS: BbsCiphersuite> Scheme for BBSplus<CS> {
     type Ciphersuite = CS;
     type PrivKey = BBSplusSecretKey;

--- a/src/schemes/generics.rs
+++ b/src/schemes/generics.rs
@@ -14,7 +14,7 @@
 
 use super::algorithms::Scheme;
 use serde::{Deserialize, Serialize};
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 #[cfg(feature = "cl03")]
 use crate::cl03::{
@@ -24,7 +24,7 @@ use crate::cl03::{
     signature::CL03Signature,
 };
 
-#[cfg(feature = "bbsplus")]
+#[cfg(feature = "min_bbs")]
 use crate::bbsplus::{
     commitment::BBSplusCommitment,
     proof::{BBSplusPoKSignature, BBSplusZKPoK},
@@ -33,25 +33,25 @@ use crate::bbsplus::{
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum BlindSignature<S: Scheme> {
-    #[cfg(feature = "bbsplus")]
+    #[cfg(feature = "min_bbs")]
     BBSplus(BBSplusSignature),
     #[cfg(feature = "cl03")]
     CL03(CL03BlindSignature),
-    _Unreachable(std::marker::PhantomData<S>),
+    _Unreachable(PhantomData<S>),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum Commitment<S: Scheme> {
-    #[cfg(feature = "bbsplus")]
+    #[cfg(feature = "min_bbs")]
     BBSplus(BBSplusCommitment),
     #[cfg(feature = "cl03")]
     CL03(CL03Commitment),
-    _Unreachable(std::marker::PhantomData<S>),
+    _Unreachable(PhantomData<S>),
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum PoKSignature<S: Scheme> {
-    #[cfg(feature = "bbsplus")]
+    #[cfg(feature = "min_bbs")]
     BBSplus(BBSplusPoKSignature),
     #[cfg(feature = "cl03")]
     CL03(CL03PoKSignature),
@@ -60,7 +60,7 @@ pub enum PoKSignature<S: Scheme> {
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum ZKPoK<S: Scheme> {
-    #[cfg(feature = "bbsplus")]
+    #[cfg(feature = "min_bbs")]
     BBSplus(BBSplusZKPoK),
     #[cfg(feature = "cl03")]
     CL03(CL03ZKPoK),
@@ -69,7 +69,7 @@ pub enum ZKPoK<S: Scheme> {
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]
 pub enum Signature<S: Scheme> {
-    #[cfg(feature = "bbsplus")]
+    #[cfg(feature = "min_bbs")]
     BBSplus(BBSplusSignature),
     #[cfg(feature = "cl03")]
     CL03(CL03Signature),

--- a/src/utils/message.rs
+++ b/src/utils/message.rs
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "bbsplus")]
+#[cfg(feature = "min_bbs")]
 pub mod bbsplus_message {
-
+    use alloc::vec::Vec;
     use crate::bbsplus::ciphersuites::BbsCiphersuite;
     use crate::errors::Error;
     use crate::utils::util::bbsplus_utils::hash_to_scalar;
@@ -52,6 +52,8 @@ pub mod bbsplus_message {
             CS::Expander: for<'a> ExpandMsg<'a>,
         {
             let map_dst = [api_id, CS::MAP_MSG_SCALAR].concat();
+            messages.into_iter().map(|m| Ok( Self{ value: hash_to_scalar::<CS>(m, &map_dst)?})).collect()
+/*
             let mut msg_scalars: Vec<Self> = Vec::new();
             for m in messages {
                 let scalar = hash_to_scalar::<CS>(m, &map_dst)?;
@@ -59,6 +61,7 @@ pub mod bbsplus_message {
             }
 
             Ok(msg_scalars)
+            */
         }
 
         /// # Description

--- a/src/utils/util.rs
+++ b/src/utils/util.rs
@@ -12,10 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(feature = "bbsplus")]
+use alloc::vec::Vec;
+
+#[cfg(any(feature = "min_bbs"))]
 pub mod bbsplus_utils {
+    use alloc::{borrow::ToOwned, vec::Vec, string::String};
+    use core::any::{Any, TypeId};
     use crate::{
-        bbsplus::ciphersuites::BbsCiphersuite, bbsplus::keys::BBSplusPublicKey, errors::Error,
+        errors::Error,
+        bbsplus::ciphersuites::BbsCiphersuite,
+        bbsplus::keys::BBSplusPublicKey,
         utils::message::bbsplus_message::BBSplusMessage,
     };
     use bls12_381_plus::{G1Affine, G1Projective, G2Affine, G2Projective, Scalar};
@@ -25,7 +31,6 @@ pub mod bbsplus_utils {
     };
     use ff::Field;
     use rand::{thread_rng, RngCore};
-    use std::any::{Any, TypeId};
 
     pub(crate) fn parse_g2_projective_compressed(slice: &[u8]) -> Result<G2Projective, Error> {
         let point = G2Affine::from_compressed(
@@ -220,6 +225,7 @@ pub mod bbsplus_utils {
     {
         let mut result: Vec<u8> = Vec::new();
         if array.len() == 0 {
+            #[cfg(feature = "std")]
             println!("Empty array");
             return result;
         }
@@ -257,6 +263,7 @@ pub mod bbsplus_utils {
                 }
             }
         } else {
+            #[cfg(feature = "std")]
             println!("Unknown struct type");
         }
 
@@ -264,21 +271,14 @@ pub mod bbsplus_utils {
     }
 
     pub fn get_messages(messages: &[BBSplusMessage], indexes: &[usize]) -> Vec<BBSplusMessage> {
-        let mut out: Vec<BBSplusMessage> = Vec::new();
-        for &i in indexes {
-            out.push(messages[i]);
-        }
-
-        out
+        indexes.into_iter().map(|&i| messages[i]).collect()
     }
 
     pub fn get_messages_vec(messages: &[Vec<u8>], indexes: &[usize]) -> Vec<Vec<u8>> {
-        let mut out: Vec<Vec<u8>> = Vec::new();
-        for &i in indexes {
-            out.push(messages[i].clone());
-        }
-
-        out
+        indexes
+            .into_iter()
+            .map(|&i| messages[i].clone())
+            .collect()
     }
 
     pub(crate) fn get_random() -> Scalar {
@@ -465,6 +465,7 @@ pub mod bbsplus_utils {
 
 #[cfg(feature = "cl03")]
 pub mod cl03_utils {
+    use alloc::vec::Vec;
     use rug::{integer::Order, Integer};
 
     //b*x = a mod m -> return x


### PR DESCRIPTION
We need to be able to use this crate in a `no_std` context. Additionally, we cannot make use of the `sha2` or `sha3` crates. This commit adds a couple of features:

`std`, which is enabled by default, must be specified in order to use `write_keypair_to_file`.  This was actually the only real dependency on `std` outside of tests.

I've split the `bbsplus` feature up. `min_bbs` enables the algorithms, but does not actually implement either the Sha256 or Shake256 schemes.

Just as written, this cannot yet compile into a `no_std` context because bls12_381_plus's `no_std` support is broken, but I'm trying to resolve that in https://github.com/mikelodder7/bls12_381_plus/pull/5.

I've also bumped group to 0.13, which should be nonbreaking because bls12_381_plus 0.8.18 already requires it.