### PR TITLE
CL03 for Selective Disclosure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ name = "zkryptium"
 path = "src/lib.rs"
 
 [features]
-default = ["bbsplus", "cl03"]
+default = ["bbsplus"]
 cl03 = ["dep:rug"]
 bbsplus = ["dep:bls12_381_plus"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ name = "zkryptium"
 path = "src/lib.rs"
 
 [features]
-default = ["bbsplus"]
+default = ["bbsplus", "cl03"]
 cl03 = ["dep:rug"]
 bbsplus = ["dep:bls12_381_plus"]
 

--- a/examples/cl03.rs
+++ b/examples/cl03.rs
@@ -95,8 +95,7 @@ mod cl03_example {
 
         log::info!("Signature unblinding and verification...");
         let unblinded_signature = blind_signature.unblind_sign(&commitment);
-        let verify =
-            unblinded_signature.verify_multiattr(issuer_keypair.public_key(), &a_bases, &messages);
+        let verify = unblinded_signature.verify_multiattr(issuer_keypair.public_key(), &a_bases, &messages);
 
         assert!(
             verify,

--- a/examples/cl03.rs
+++ b/examples/cl03.rs
@@ -160,8 +160,7 @@ fn main() {
 
     let args: Vec<String> = env::args().collect();
 
-    println!("args: {:?}", args);
-    if args.len() != 3 {
+    if args.len() != 2 {
         println!(
             "Usage: {} <cipher_suite>
                 Ciphersuites:
@@ -170,7 +169,6 @@ fn main() {
         );
         return;
     }
-
 
     let cipher_suite = &args[1];
 

--- a/examples/cl03.rs
+++ b/examples/cl03.rs
@@ -99,7 +99,7 @@ mod cl03_example {
 
         assert!(
             verify,
-            "Error! The unblided signature verification should PASS!"
+            "Error! The unblinded signature verification should PASS!"
         );
         log::info!("Signature is VALID!");
 
@@ -109,7 +109,7 @@ mod cl03_example {
 
         assert!(
             verify,
-            "Error! The unblided signature verification should PASS!"
+            "Error! The unblinded signature verification should PASS!"
         );
         log::info!("SD Signature is VALID!");
 

--- a/examples/cl03_multiattr.rs
+++ b/examples/cl03_multiattr.rs
@@ -51,7 +51,7 @@ mod cl03_example {
             })
             .collect();
 
-        let undisclosed_message_indexes = [0, 1];
+        let undisclosed_message_indexes = [0,2];
         let signature = Signature::<CL03<CL1024Sha256>>::sign_multiattr(
             issuer_keypair.public_key(),
             issuer_keypair.private_key(),
@@ -82,8 +82,8 @@ mod cl03_example {
         );
 
         log::info!("Signature for Selective Disclosure is VALID!");
-        let unrevealed_message_indexes = [2];
-        let revealed_message_indexes = [0, 1];
+        let unrevealed_message_indexes = undisclosed_message_indexes;
+        let revealed_message_indexes = [1];
         let revealed_messages: Vec<CL03Message> = messages
             .iter()
             .enumerate()

--- a/examples/cl03_multiattr.rs
+++ b/examples/cl03_multiattr.rs
@@ -1,0 +1,118 @@
+// Copyright 2023 Fondazione LINKS
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#[cfg(feature = "cl03")]
+mod cl03_example {
+    use digest::Digest;
+    use zkryptium::{
+        cl03::{bases::Bases, ciphersuites::CLCiphersuite, keys::CL03CommitmentPublicKey},
+        keys::pair::KeyPair,
+        schemes::algorithms::{Ciphersuite, Scheme, CL03},
+        schemes::generics::{BlindSignature, Commitment, PoKSignature, ZKPoK},
+        utils::message::cl03_message::CL03Message,
+    };
+    use zkryptium::cl03::ciphersuites::CL1024Sha256;
+    use zkryptium::schemes::generics::Signature;
+
+    pub(crate) fn cl03_main<S: Scheme>()
+    where
+        S::Ciphersuite: CLCiphersuite,
+        <S::Ciphersuite as Ciphersuite>::HashAlg: Digest,
+    {
+        const MSGS: &[&str] = &[
+            "9872ad089e452c7b6e283dfac2a80d58e8d0ff71cc4d5e310a1debdda4a45f02",
+            "9872ad089e452c7b6e283dfac2a80d58e8d0ff71cc4d5e310a1debdda4a45f03",
+            "9872ad089e452c7b6e283dfac2a80d58e8d0ff71cc4d5e310a1debdda4a45f04",
+        ];
+
+        log::info!("Messages: {:?}", MSGS);
+
+        log::info!("Keypair Generation");
+        let issuer_keypair = KeyPair::<CL03<S::Ciphersuite>>::generate();
+
+        log::info!("Bases generation");
+        let a_bases = Bases::generate(issuer_keypair.public_key(), MSGS.len());
+
+        let messages: Vec<CL03Message> = MSGS
+            .iter()
+            .map(|&m| {
+                CL03Message::map_message_to_integer_as_hash::<S::Ciphersuite>(
+                    &hex::decode(m).unwrap(),
+                )
+            })
+            .collect();
+
+        let unrevealed_message_indexes = [0usize];
+        let revealed_message_indexes = [1usize, 2usize];
+        let revealed_messages: Vec<CL03Message> = messages
+            .iter()
+            .enumerate()
+            .filter(|&(i, _)| revealed_message_indexes.contains(&i))
+            .map(|(_, m)| m.clone())
+            .collect();
+
+        let signature = Signature::<CL03<CL1024Sha256>>::sign_multiattr(
+            issuer_keypair.public_key(),
+            issuer_keypair.private_key(),
+            &a_bases,
+            &messages
+        );
+
+        let verify = signature.verify_multiattr(issuer_keypair.public_key(), &a_bases, &messages);
+
+        assert!(
+            verify,
+            "Error! The unblided signature verification should PASS!"
+        );
+        log::info!("Signature is VALID!");
+    }
+}
+
+#[cfg(feature = "cl03")]
+fn main() {
+    use std::env;
+    use zkryptium::schemes::algorithms::CL03_CL1024_SHA256;
+
+    dotenv::dotenv().ok();
+    env_logger::init();
+
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() != 2 {
+        println!(
+            "Usage: {} <cipher_suite>
+                Ciphersuites:
+                    - CL1024-SHA-256",
+            args[0]
+        );
+        return;
+    }
+
+    let cipher_suite = &args[1];
+
+    match cipher_suite.as_str() {
+        "CL1024-SHA-256" => {
+            println!("\n");
+            log::info!("Ciphersuite: CL1024-SHA-256");
+            cl03_example::cl03_main::<CL03_CL1024_SHA256>();
+        }
+        _ => {
+            println!("Unknown cipher suite: {}", cipher_suite);
+            // Handle other cipher suites or raise an error if necessary
+        }
+    }
+}
+
+#[cfg(not(feature = "cl03"))]
+fn main() {}

--- a/examples/cl03_multiattr.rs
+++ b/examples/cl03_multiattr.rs
@@ -20,7 +20,7 @@ mod cl03_example {
     use zkryptium::cl03::keys::CL03CommitmentPublicKey;
     use zkryptium::keys::pair::KeyPair;
     use zkryptium::schemes::algorithms::{Ciphersuite, Scheme, CL03};
-    use zkryptium::schemes::generics::{Commitment, PoKSignature, Signature, ZKPoK};
+    use zkryptium::schemes::generics::{PoKSignature, Signature};
     use zkryptium::utils::message::cl03_message::CL03Message;
 
     pub(crate) fn cl03_main<S: Scheme>()
@@ -51,7 +51,7 @@ mod cl03_example {
             })
             .collect();
 
-        let undisclosed_message_indexes = [0usize, 2usize];
+        let undisclosed_message_indexes = [0, 1];
         let signature = Signature::<CL03<CL1024Sha256>>::sign_multiattr(
             issuer_keypair.public_key(),
             issuer_keypair.private_key(),
@@ -82,10 +82,8 @@ mod cl03_example {
         );
 
         log::info!("Signature for Selective Disclosure is VALID!");
-        log::info!("Computation of a Zero-Knowledge proof-of-knowledge of committed messages");
-
-        let unrevealed_message_indexes = [0usize];
-        let revealed_message_indexes = [1usize, 2usize];
+        let unrevealed_message_indexes = [2];
+        let revealed_message_indexes = [0, 1];
         let revealed_messages: Vec<CL03Message> = messages
             .iter()
             .enumerate()

--- a/examples/cl03_multiattr.rs
+++ b/examples/cl03_multiattr.rs
@@ -15,15 +15,12 @@
 #[cfg(feature = "cl03")]
 mod cl03_example {
     use digest::Digest;
-    use zkryptium::{
-        cl03::{bases::Bases, ciphersuites::CLCiphersuite, keys::CL03CommitmentPublicKey},
-        keys::pair::KeyPair,
-        schemes::algorithms::{Ciphersuite, Scheme, CL03},
-        schemes::generics::{BlindSignature, Commitment, PoKSignature, ZKPoK},
-        utils::message::cl03_message::CL03Message,
-    };
-    use zkryptium::cl03::ciphersuites::CL1024Sha256;
+    use zkryptium::cl03::bases::Bases;
+    use zkryptium::cl03::ciphersuites::{CL1024Sha256, CLCiphersuite};
+    use zkryptium::keys::pair::KeyPair;
+    use zkryptium::schemes::algorithms::{Ciphersuite, Scheme, CL03};
     use zkryptium::schemes::generics::Signature;
+    use zkryptium::utils::message::cl03_message::CL03Message;
 
     pub(crate) fn cl03_main<S: Scheme>()
     where
@@ -37,13 +34,13 @@ mod cl03_example {
         ];
 
         log::info!("Messages: {:?}", MSGS);
-
         log::info!("Keypair Generation");
+
         let issuer_keypair = KeyPair::<CL03<S::Ciphersuite>>::generate();
 
         log::info!("Bases generation");
-        let a_bases = Bases::generate(issuer_keypair.public_key(), MSGS.len());
 
+        let a_bases = Bases::generate(issuer_keypair.public_key(), MSGS.len());
         let messages: Vec<CL03Message> = MSGS
             .iter()
             .map(|&m| {
@@ -54,28 +51,35 @@ mod cl03_example {
             .collect();
 
         let unrevealed_message_indexes = [0usize];
-        let revealed_message_indexes = [1usize, 2usize];
-        let revealed_messages: Vec<CL03Message> = messages
-            .iter()
-            .enumerate()
-            .filter(|&(i, _)| revealed_message_indexes.contains(&i))
-            .map(|(_, m)| m.clone())
-            .collect();
-
         let signature = Signature::<CL03<CL1024Sha256>>::sign_multiattr(
             issuer_keypair.public_key(),
             issuer_keypair.private_key(),
             &a_bases,
             &messages
         );
-
         let verify = signature.verify_multiattr(issuer_keypair.public_key(), &a_bases, &messages);
+
+        log::info!("Bases:\t{:?}", a_bases);
+        log::info!("Messages:\t{:?}", messages);
 
         assert!(
             verify,
-            "Error! The unblided signature verification should PASS!"
+            "Error! The signature verification should PASS!"
         );
         log::info!("Signature is VALID!");
+
+        let (sd_messages, sd_bases) = signature.disclose_selectively(&messages, a_bases.clone(), issuer_keypair.public_key(), unrevealed_message_indexes.as_slice());
+
+        log::info!("SDBases:\t{:?}", sd_bases);
+        log::info!("SDMessages:\t{:?}", sd_messages);
+
+        let verify = signature.verify_multiattr(issuer_keypair.public_key(), &sd_bases, &sd_messages);
+
+        assert!(
+            verify,
+            "Error! The signature verification should PASS!"
+        );
+        log::info!("Signature for Selective Disclosure is VALID!");
     }
 }
 

--- a/examples/cl03_multiattr.rs
+++ b/examples/cl03_multiattr.rs
@@ -51,7 +51,10 @@ mod cl03_example {
             })
             .collect();
 
-        let undisclosed_message_indexes = [0,2];
+        let undisclosed_message_indexes = [1];
+        let revealed_message_indexes = [0, 2];
+        let unrevealed_message_indexes = undisclosed_message_indexes;
+
         let signature = Signature::<CL03<CL1024Sha256>>::sign_multiattr(
             issuer_keypair.public_key(),
             issuer_keypair.private_key(),
@@ -82,8 +85,6 @@ mod cl03_example {
         );
 
         log::info!("Signature for Selective Disclosure is VALID!");
-        let unrevealed_message_indexes = undisclosed_message_indexes;
-        let revealed_message_indexes = [1];
         let revealed_messages: Vec<CL03Message> = messages
             .iter()
             .enumerate()

--- a/src/cl03/proof.rs
+++ b/src/cl03/proof.rs
@@ -28,7 +28,7 @@ use crate::{
     schemes::generics::{Commitment, PoKSignature, ZKPoK},
     utils::message::cl03_message::CL03Message,
 };
-use digest::{Digest, Mac};
+use digest::{Digest};
 use rug::{ops::Pow, Integer};
 use serde::{Deserialize, Serialize};
 
@@ -184,7 +184,6 @@ impl<CS: CLCiphersuite> PoKSignature<CL03<CS>> {
                         value: proof_mi,
                         commitment: cmi,
                     } = CLSPoK.proofs_commited_mi.get(idx).expect("index overflow");
-                    println!("CLSPoK = {:?}", CLSPoK.proofs_commited_mi);
 
                     let boolean_proof_mi = proof_mi.nisp2sec_verify_proof::<CS>(
                         &cmi,
@@ -192,11 +191,11 @@ impl<CS: CLCiphersuite> PoKSignature<CL03<CS>> {
                         &commitment_pk.h,
                         &commitment_pk.N,
                     );
-                    println!("idx = {idx} - i = {i} - unrevealed_message_indexes = {:?}!", unrevealed_message_indexes);
                     if !boolean_proof_mi {
                         println!("Knowledge verification of mi Failed!");
                         return false;
                     }
+
                     let boolean_rproofs_mi = CLSPoK
                         .range_proofs_commited_mi
                         .get(idx)

--- a/src/cl03/proof.rs
+++ b/src/cl03/proof.rs
@@ -179,7 +179,7 @@ impl<CS: CLCiphersuite> PoKSignature<CL03<CS>> {
                 //Verify RANGE PROOFS mi
                 let mut idx: usize = 0;
                 for i in unrevealed_message_indexes {
-                    let gi = &commitment_pk.g_bases.get(*i).expect("unreaveled_message_indexes not valid with respect to the commitment_pk.g_bases!");
+                    let gi = &commitment_pk.g_bases.get(*i).expect("unrevealed_message_indexes not valid with respect to the commitment_pk.g_bases!");
                     let ProofOfValue {
                         value: proof_mi,
                         commitment: cmi,

--- a/src/cl03/signature.rs
+++ b/src/cl03/signature.rs
@@ -61,6 +61,38 @@ impl<CS: CLCiphersuite> Signature<CL03<CS>> {
         Self::CL03(sig)
     }
 
+    pub fn sign_multiattr(
+        pk: &CL03PublicKey,
+        sk: &CL03SecretKey,
+        a_bases: &Bases,
+        messages: &[CL03Message],
+    ) -> Self {
+        let mut e = random_prime(CS::le);
+        let phi_n = (&sk.p - Integer::from(1)) * (&sk.q - Integer::from(1));
+
+        while ((&e > &Integer::from(2).pow(CS::le - 1))
+            && (&e < &Integer::from(2).pow(CS::le))
+            && (Integer::from(e.gcd_ref(&phi_n)) == 1))
+            == false
+        {
+            e = random_prime(CS::le);
+        }
+
+        let s = random_bits(CS::ls);
+        let e2n = Integer::from(e.invert_ref(&phi_n).unwrap());
+        // v = powmod((powmod(pk['a0'], m, pk['N']) * powmod(pk['b'], s, pk['N']) * pk['c']), (e2n), pk['N'])
+        let mut v: Integer = Integer::from(1);
+        for (index, message) in messages.iter().enumerate() {
+            v = v * Integer::from(a_bases.0[index].pow_mod_ref(&message.value, &pk.N).unwrap())
+        }
+        v = (v * Integer::from(pk.b.pow_mod_ref(&s, &pk.N).unwrap()) * &pk.c)
+            .pow_mod(&e2n, &pk.N)
+            .unwrap();
+
+        let sig = CL03Signature { e, s, v };
+        Self::CL03(sig)
+    }
+
     //TODO: tenere solo verify_multiattr visto che funzione anche con un solo messaggio?
     pub fn verify(&self, pk: &CL03PublicKey, a_bases: &Bases, message: &CL03Message) -> bool {
         let sign = self.cl03Signature();

--- a/src/cl03/signature.rs
+++ b/src/cl03/signature.rs
@@ -156,7 +156,7 @@ impl<CS: CLCiphersuite> Signature<CL03<CS>> {
 
         let mut sd_messages: Vec<CL03Message> = Vec::from(messages);
 
-        if unrevealed_indexes.len() == messages.len() {
+        if unrevealed_indexes.len() == 0 {
             return (sd_messages, a_bases)
         }
 

--- a/src/cl03/signature.rs
+++ b/src/cl03/signature.rs
@@ -148,6 +148,28 @@ impl<CS: CLCiphersuite> Signature<CL03<CS>> {
         false
     }
 
+    pub fn disclose_selectively(&self, messages: &[CL03Message], a_bases: Bases, pk: &CL03PublicKey, unrevealed_indexes: &[usize]) -> (Vec<CL03Message>, Bases) {
+
+        if messages.len() != a_bases.0.len() {
+            panic!("Mismatch between messages and bases length!");
+        }
+
+        let mut sd_messages: Vec<CL03Message> = Vec::from(messages);
+
+        if unrevealed_indexes.len() == messages.len() {
+            return (sd_messages, a_bases)
+        }
+
+        let mut sd_bases: Bases = a_bases.clone();
+
+        for index in unrevealed_indexes {
+            sd_bases.0[*index] = Integer::from(a_bases.0[*index].pow_mod_ref(&messages[*index].value, &pk.N).unwrap());
+            sd_messages[*index].value = Integer::from(1);
+        }
+
+        (sd_messages, sd_bases)
+    }
+
     pub fn cl03Signature(&self) -> &CL03Signature {
         match self {
             Self::CL03(inner) => inner,


### PR DESCRIPTION
- Fixed typos.
- Created sign_multiattr.
- Created function disclose_selectively for modifying messages and bases to permit the verification of the signature with a subset of messages.
- Modified Proof::proof_gen (specifically, commit_with_commitment_pk).