### PR TITLE
fix: clean dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,34 +14,29 @@ categories = [ "cryptography", "authentication" ]
 
 [dependencies]
 rand = {version = "0.8.5"}
-zeroize = { version = "1.8.1" }
 serde = { version = "1.0.25", default-features = false, features = ["derive", "serde_derive"] }
 serde_json = "1.0.59"
 hex = "0.4.3"
-thiserror = "1.0.30"
+thiserror = "2.0.12"
 
 # cl03
 rug = { version = "1.27.0", features = ["serde"], optional = true }
 rand_chacha = { version = "0.9.0", optional = true }
 
-
 sha3 = "0.10.8"
 sha2 = "0.10.6"
-hkdf = "0.12.3"
 digest = "0.10.6"
 
 # bbsplus
 bls12_381_plus = { version = "0.8.13", optional = true }
-ff = "0.13.0"
-group = "0.10"
+ff = "0.13.1"
+group = "0.13.0"
 elliptic-curve = "0.13.4"
 
-
+[dev-dependencies]
 log = "0.4.0"
-env_logger = "0.10.0"
+env_logger = "0.11.8"
 dotenvy = "0.15.7"
-
-
 
 [lib]
 name = "zkryptium"
@@ -52,7 +47,6 @@ default = ["bbsplus", "bbsplus_blind"]
 cl03 = ["dep:rug", "dep:rand_chacha"]
 bbsplus = ["dep:bls12_381_plus"]
 bbsplus_blind = ["bbsplus"]
-
 
 [[example]]
 name = "bbsplus_blind"


### PR DESCRIPTION
This PR removes unused dependencies, and moves dependencies only used in examples to dev-dependencies.

I needed these changes to make this package work in a Zero Knowledge Virtual Machine (ZKVM) which does not have access to the `os` dependency used by the `env_logger` - hence marking this as a fix.